### PR TITLE
add implicit request handlers

### DIFF
--- a/lib/mediate/request.rb
+++ b/lib/mediate/request.rb
@@ -6,5 +6,71 @@ module Mediate
   # returns a response from its handler.
   #
   class Request
+    IMPLICIT_HANDLER_CLASS_NAME = "Handler"
+
+    #
+    # Registers a handler for this Request type using the given block as the handle method.
+    #
+    # @param [Mediate::Mediator] mediator the instance to register the handler on
+    # @param [Proc] &proc the block that will handle the request
+    #
+    # @raises [ArgumentError] if no block is given
+    #
+    # @example When a request of this type is dispatched, the handle_with block will run
+    #   class MyRequest < Mediate::Request
+    #     handle_with do |request|
+    #       ## do something with request...
+    #     end
+    #   end
+    def self.handle_with(mediator = Mediator.mediator, &proc)
+      raise ArgumentError, "expected block to be passed to #handle_with." unless proc
+
+      if implicit_handler_defined?
+        raise "#{name}::#{IMPLICIT_HANDLER_CLASS_NAME} is already defined. Cannot create implicit handler."
+      end
+
+      handler_class = define_handler(proc)
+      const_set(IMPLICIT_HANDLER_CLASS_NAME, handler_class)
+      mediator.register_request_handler(handler_class, self)
+    end
+
+    #
+    # If an implicit handler is defined for this Request using the #handle_with method,
+    # this will return an instance of it. Use this for testing the handler.
+    #
+    # @return [Mediate::RequestHandler] the implicit handler class for this Request
+    #
+    # @raise [RuntimeError] if no implicit handler is defined
+    #
+    # @example Create an instance and call #handle on it to test it
+    #   handler = MyRequest.create_implicit_handler
+    #   result = handler.handle(MyRequest.new)
+    def self.create_implicit_handler
+      raise "Implicit handler is not defined." unless implicit_handler_defined?
+
+      const_get(IMPLICIT_HANDLER_CLASS_NAME).new
+    end
+
+    def self.undefine_implicit_handler
+      return unless implicit_handler_defined?
+
+      remove_const(IMPLICIT_HANDLER_CLASS_NAME)
+    end
+
+    def self.define_handler(proc)
+      Class.new(RequestHandler) do
+        @@handle_proc = proc # rubocop:disable Style/ClassVars
+        def handle(request)
+          @@handle_proc.call(request)
+        end
+      end
+    end
+
+    def self.implicit_handler_defined?
+      const_defined?(IMPLICIT_HANDLER_CLASS_NAME)
+    end
+
+    private_constant :IMPLICIT_HANDLER_CLASS_NAME
+    private_class_method :define_handler, :implicit_handler_defined?
   end
 end

--- a/spec/lib/mediate/request_spec.rb
+++ b/spec/lib/mediate/request_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module RequestSpec
+  class TestRequest < Mediate::Request
+    attr_reader :first, :second
+
+    def initialize(first, second)
+      @first = first
+      @second = second
+      super()
+    end
+  end
+end
+
+RSpec.describe Mediate::Request do
+  let(:mediator) { Class.new(Mediate::Mediator).instance }
+
+  after(:each) do
+    RequestSpec::TestRequest.undefine_implicit_handler
+  end
+
+  describe "#handle_with" do
+    it "registers a handler that runs the given block on the request" do
+      a = "abc"
+      b = "_xyz"
+      expected = a + b
+      RequestSpec::TestRequest.handle_with(mediator) { |r| r.first + r.second }
+      actual = mediator.dispatch(RequestSpec::TestRequest.new(a, b))
+      expect(actual).to eq(expected)
+    end
+
+    it "creates a RequestHandler class that can be created with #create_implicit_handler" do
+      a = "abc"
+      b = "_xyz"
+      expected = a + b
+      RequestSpec::TestRequest.handle_with(mediator) { |r| r.first + r.second }
+      request = RequestSpec::TestRequest.new(a, b)
+      actual = RequestSpec::TestRequest.create_implicit_handler.handle(request)
+      expect(actual).to eq(expected)
+    end
+
+    it "raises ArgumentError if no block given" do
+      expect { RequestSpec::TestRequest.handle_with(mediator) }.to raise_error(ArgumentError, /expected block/)
+    end
+
+    it "raises if implicit handler is already defined" do
+      RequestSpec::TestRequest.handle_with(mediator) { |_r| 1 }
+      expect { RequestSpec::TestRequest.handle_with(mediator) { |_r| 1 } }.to raise_error(/already defined/)
+    end
+
+    it "raises if handler already registered for request class" do
+      mediator.register_request_handler(Stubs::RequestHandler, RequestSpec::TestRequest)
+      expect { RequestSpec::TestRequest.handle_with(mediator) { |_r| 1 } }
+        .to raise_error(Mediate::Errors::RequestHandlerAlreadyExistsError)
+    end
+
+    it "registers only for that request class" do
+      RequestSpec::TestRequest.handle_with(mediator) { |_r| 1 }
+      expect { mediator.dispatch(Stubs::Request.new) }.to raise_error(Mediate::Errors::NoHandlerError)
+    end
+  end
+
+  describe "#create_implicit_handler" do
+    it "raises if handler class is not defined" do
+      expect { RequestSpec::TestRequest.create_implicit_handler }.to raise_error(/handler is not defined/)
+    end
+
+    it "returns instance of implicit handler class" do
+      RequestSpec::TestRequest.handle_with(mediator) { |_r| 1 }
+      actual = RequestSpec::TestRequest.create_implicit_handler
+      expect(actual).to be_truthy
+      expect(actual).to be_a(Mediate::RequestHandler)
+      expect(actual).to respond_to(:handle)
+    end
+  end
+end


### PR DESCRIPTION
This adds the `handle_with` method to `Mediate::Request`, which dynamically defines a `Mediate::RequestHandler` with the given block as its `handle` method and registers it as the handler for that request class.  This will greatly reduce boilerplate for defining simple handlers.

For example, this:

```ruby
class Get < Mediate::Request
  attr_reader :id
  def initialize(id)
    @id = id
  end

  class Handler < Mediate::RequestHandler
    handles Get

    def handle(request)
      Model.find(request.id)
    end
  end
end
```

can be turned into this:

```ruby
class Get < Mediate::Request
  attr_reader :id
  def initialize(id)
    @id = id
  end

  handle_with { |request| Model.find(request.id) }
end
```

This also adds a `create_implicit_handler` method to `Mediate::Request`, which will create an instance of the implicit handler class, if it is defined.  This allows for easily testing that `handle` block.  For example, something like this:

```ruby
it "finds the model" do
  expected = Model.find(1)
  actual = Get.create_implicit_handler.handle(Get.new(expected.id))
  expect(actual).to eq(expected)
end
```