### PR TITLE
Fix implicit handlers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mediate (0.1.0)
+    mediate (0.1.1)
       concurrent-ruby (~> 1.1)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Note that only one handler can be registered for a particular request class; att
 
 #### Implicit handler declaration
 
-For simple handlers, you can skip the explicit `RequestHandler` declaration above and instead pass a block to `Request.handle_with`.
+For simple handlers, you can skip the explicit `RequestHandler` declaration above and instead pass a lambda to `Request.handle_with`.
 
 ```ruby
 class Ping < Mediate::Request
@@ -107,14 +107,14 @@ class Ping < Mediate::Request
         super()
     end
     # This will have the same behavior as the PingHandler declaration above.
-    handle_with { |request| "Received: #{request.message}" }
+    handle_with ->(request) { "Received: #{request.message}" }
 end
 
 response = Mediate.dispatch(Ping.new('hello'))
 puts response # 'Received: hello'
 ```
 
-Behind the scenes, this defines a `Ping::Handler` class that calls the given block in its `handle` method.  For testing purposes, you can get an instance of this handler class by calling `Mediate::Request.create_implicit_handler` (see [Testing implicit request handlers](#testing-implicit-request-handlers)).
+Behind the scenes, this defines a `Ping::Handler` class that calls the given lambda in its `handle` method.  For testing purposes, you can get an instance of this handler class by calling `Mediate::Request.create_implicit_handler` (see [Testing implicit request handlers](#testing-implicit-request-handlers)).
 
 #### Request polymorphism
 
@@ -129,7 +129,7 @@ Unless we registered a handler for `SubPing` explicitly.
 
 ```ruby
 class SubPing < Ping
-    handle_with { |request| "Received from SubPing: #{request.message}" }
+    handle_with ->(request) { "Received from SubPing: #{request.message}" }
 end
 puts Mediate.dispatch(SubPing.new('howdy')) # 'Received from SubPing: howdy'
 ```
@@ -252,11 +252,11 @@ Special consideration is only required when testing paths that invoke methods on
 
 #### Testing implicit request handlers
 
-How can you test a request handler defined using `handle_with` and a block like the following?
+How can you test a request handler defined using `handle_with` and a lambda like the following?
 
 ```ruby
 class ExampleRequest < Mediate::Request
-    handle_with do |request|
+    handle_with lambda do |request|
         # ....
     end
 end

--- a/lib/mediate.rb
+++ b/lib/mediate.rb
@@ -33,7 +33,7 @@ module Mediate
   end
 
   #
-  # Sends a notification to all register handlers for the given notification's type.
+  # Sends a notification to all registered handlers for the given notification's type.
   #
   # @param [Mediate::Notification] notification
   #

--- a/lib/mediate/mediator.rb
+++ b/lib/mediate/mediator.rb
@@ -51,7 +51,7 @@ module Mediate
     end
 
     #
-    # Sends a notification to all register handlers for the given notification's type.
+    # Sends a notification to all registered handlers for the given notification's type.
     #
     # @param [Mediate::Notification] notification
     #

--- a/lib/mediate/version.rb
+++ b/lib/mediate/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Mediate
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/spec/lib/mediate/request_spec.rb
+++ b/spec/lib/mediate/request_spec.rb
@@ -10,6 +10,19 @@ module RequestSpec
       super()
     end
   end
+
+  class AnotherRequest < Mediate::Request
+    attr_reader :value
+
+    def initialize(value)
+      @value = value
+      super()
+    end
+  end
+
+  class SubRequest < TestRequest
+    attr_reader :first, :second
+  end
 end
 
 RSpec.describe Mediate::Request do
@@ -17,14 +30,16 @@ RSpec.describe Mediate::Request do
 
   after(:each) do
     RequestSpec::TestRequest.undefine_implicit_handler
+    RequestSpec::AnotherRequest.undefine_implicit_handler
+    RequestSpec::SubRequest.undefine_implicit_handler
   end
 
   describe "#handle_with" do
-    it "registers a handler that runs the given block on the request" do
+    it "registers a handler that runs the given lambda on the request" do
       a = "abc"
       b = "_xyz"
       expected = a + b
-      RequestSpec::TestRequest.handle_with(mediator) { |r| r.first + r.second }
+      RequestSpec::TestRequest.handle_with(->(r) { r.first + r.second }, mediator)
       actual = mediator.dispatch(RequestSpec::TestRequest.new(a, b))
       expect(actual).to eq(expected)
     end
@@ -33,29 +48,56 @@ RSpec.describe Mediate::Request do
       a = "abc"
       b = "_xyz"
       expected = a + b
-      RequestSpec::TestRequest.handle_with(mediator) { |r| r.first + r.second }
+      RequestSpec::TestRequest.handle_with(->(r) { r.first + r.second }, mediator)
       request = RequestSpec::TestRequest.new(a, b)
       actual = RequestSpec::TestRequest.create_implicit_handler.handle(request)
       expect(actual).to eq(expected)
     end
 
-    it "raises ArgumentError if no block given" do
-      expect { RequestSpec::TestRequest.handle_with(mediator) }.to raise_error(ArgumentError, /expected block/)
+    it "registers distinct handlers for distinct request classes" do
+      test_request = RequestSpec::TestRequest.new("a", "b")
+      test_request_expected = test_request.first + test_request.second
+      another_test_request = RequestSpec::AnotherRequest.new("z")
+      another_test_request_expected = another_test_request.value
+      RequestSpec::TestRequest.handle_with(->(r) { r.first + r.second }, mediator)
+      RequestSpec::AnotherRequest.handle_with(->(r) { r.value }, mediator)
+      test_request_actual = RequestSpec::TestRequest.create_implicit_handler.handle(test_request)
+      another_test_request_actual = RequestSpec::AnotherRequest.create_implicit_handler.handle(another_test_request)
+      expect(test_request_actual).to eq(test_request_expected)
+      expect(another_test_request_actual).to eq(another_test_request_expected)
+    end
+
+    it "registers distinct handlers for request superclass and subclass" do
+      test_request = RequestSpec::TestRequest.new("a", "b")
+      test_request_expected = test_request.first + test_request.second
+      sub_test_request = RequestSpec::SubRequest.new(5, 4)
+      sub_test_request_expected = sub_test_request.first - sub_test_request.second
+      RequestSpec::TestRequest.handle_with(->(r) { r.first + r.second }, mediator)
+      RequestSpec::SubRequest.handle_with(->(r) { r.first - r.second }, mediator)
+      test_request_actual = RequestSpec::TestRequest.create_implicit_handler.handle(test_request)
+      sub_test_request_actual = RequestSpec::SubRequest.create_implicit_handler.handle(sub_test_request)
+      expect(test_request_actual).to eq(test_request_expected)
+      expect(sub_test_request_actual).to eq(sub_test_request_expected)
+    end
+
+    it "raises ArgumentError if no lambda given" do
+      expect { RequestSpec::TestRequest.handle_with(nil, mediator) }.to raise_error(ArgumentError, /expected lambda/)
     end
 
     it "raises if implicit handler is already defined" do
-      RequestSpec::TestRequest.handle_with(mediator) { |_r| 1 }
-      expect { RequestSpec::TestRequest.handle_with(mediator) { |_r| 1 } }.to raise_error(/already defined/)
+      RequestSpec::TestRequest.handle_with(->(_r) { 1 }, mediator)
+      expect { RequestSpec::TestRequest.handle_with(->(_r) { 1 }, mediator) }
+        .to raise_error(Mediate::Errors::RequestHandlerAlreadyExistsError)
     end
 
     it "raises if handler already registered for request class" do
       mediator.register_request_handler(Stubs::RequestHandler, RequestSpec::TestRequest)
-      expect { RequestSpec::TestRequest.handle_with(mediator) { |_r| 1 } }
+      expect { RequestSpec::TestRequest.handle_with(->(_r) { 1 }, mediator) }
         .to raise_error(Mediate::Errors::RequestHandlerAlreadyExistsError)
     end
 
     it "registers only for that request class" do
-      RequestSpec::TestRequest.handle_with(mediator) { |_r| 1 }
+      RequestSpec::TestRequest.handle_with(->(_r) { 1 }, mediator)
       expect { mediator.dispatch(Stubs::Request.new) }.to raise_error(Mediate::Errors::NoHandlerError)
     end
   end
@@ -66,7 +108,7 @@ RSpec.describe Mediate::Request do
     end
 
     it "returns instance of implicit handler class" do
-      RequestSpec::TestRequest.handle_with(mediator) { |_r| 1 }
+      RequestSpec::TestRequest.handle_with(->(_r) { 1 }, mediator)
       actual = RequestSpec::TestRequest.create_implicit_handler
       expect(actual).to be_truthy
       expect(actual).to be_a(Mediate::RequestHandler)


### PR DESCRIPTION
- The way of defining implicit handlers was broken because class variable was getting reset when new handler was defined.
- Switch to using `define_method` allowing the passed proc to be included in closure.
- `handle_with` takes lambda instead of block